### PR TITLE
reword question about user privacy

### DIFF
--- a/_data/headlines.yml
+++ b/_data/headlines.yml
@@ -1,7 +1,7 @@
 -
-    title: "Puis-je vous demander le mot de passe de votre ordinateur, de votre
-    boîte mail et de votre compte Facebook ? Promis, je ne ferai rien de mal,
-    seulement lire."
+    title: "Puis-je vous demander une copie de tous vos emails, de vos messages
+    et photos sur Facebook, et de tous les fichiers sur votre ordinateur ?
+    J'aimerais tout savoir sur votre vie privée."
     content: >
         Comment oseriez-vous répondre _non_ ? Lorsque vous n'avez rien à cacher,
         vous ne pouvez pas faire de **distinction** entre ce que vous admettez


### PR DESCRIPTION
I would like to help making this website more striking and convincing, and I believe that the first question asked to the reader is a bit of a [loaded question](https://yourlogicalfallacyis.com/loaded-question).

It tries to make an analogy with "having nothing to hide from external eyes", and to show how bad it is to make one's entire life completely public. However, I believe the question goes too far by asking to "trustingly surrender a password", making replying "yes" to this question even worse than replying "yes" to mass surveillance:
- Asking for someone's password not only allows you to see every bit of personal data, but also allows you to impersonate the user, and modify/delete their data. What if I'm OK with all my email being read by the government, but I don't want someone to send emails in my name, or delete emails before I can read them?
- Asking for someone's trust about not doing such things is not the same as having a proven read-only access to their data. What if I'm OK with you reading all my emails, but I wouldn't ever trust you with the passwords to all my accounts?

An extreme example of the fallacy I'm pointing out would be: "Oh, you don't have anything to hide? Then let me point a sniper rifle at your house and watch you everyday. I promise I won't pull the trigger, I just want to watch you". OK, the sniper lens illustrates how bad it is that someone watches your every move at home, but the fact that this person can also shoot you at any time doesn't have anything to do with the surveillance argument.

Neither has identity theft and control over private data anything to do with the argument against mass surveillance.

I would also like to thank you very much for setting up such a great website, and showing people that they don't really "have nothing to hide" ― I believe that's the biggest fallacy here.
