### PR TITLE
Vidéos chez Framatube et màj conf. « Je n'ai rien à cacher » (fix #41)

### DIFF
--- a/_data/videos.yml
+++ b/_data/videos.yml
@@ -1,8 +1,8 @@
 -
     title: "Je n'ai rien à cacher"
-    url: //www.youtube.com/embed/BRrk5_-kXHw
+    url: //framatube.org/media/je-nai-rien-a-cacher/embed_player
     extra_url: http://ldn-fai.net/je-nai-rien-a-cacher/
-    date_fr: 17 avril 2014
+    date_fr: 14 avril 2015
     authors:
         - Julien Vaubourg
     abstract: >
@@ -12,10 +12,11 @@
         nous utilisons tous plus ou moins ses services et ceux des entreprises qui
         développent le même mode de pensée sur Internet. Mais au fait, n'avons-nous
         vraiment rien à cacher ?
+        [Transcription textuelle](https://www.april.org/je-nai-rien-cacher-julien-vaubourg)
 
 -
     title: "Si, vous avez quelque chose à cacher"
-    url: //www.youtube.com/embed/RKMgqWTsa0Q
+    url: //framatube.org/media/si-vous-avez-quelque-chose-a-cacher/embed_player
     extra_url: http://www.april.org/si-vous-avez-quelque-chose-cacher-conference-de-numendil-passage-en-seine-en-2013
     date_fr: 21 juin 2013
     authors:
@@ -32,7 +33,7 @@
 
 -
     title: "♫ Rien à cacher"
-    url: //www.youtube.com/embed/rEwf4sDgxHo
+    url: //framatube.org/media/rien-a-cacher/embed_player
     extra_url:
     date_fr: 06 février 2014
     authors:

--- a/_includes/video_item.html
+++ b/_includes/video_item.html
@@ -15,7 +15,7 @@
             </p>
         </div>
         <div class="col-md-5 text-center video">
-            <iframe src="{{ video.url }}" frameborder="0" allowfullscreen></iframe>
+            <iframe width="400" height="225" src="{{ video.url }}" frameborder="0" allowfullscreen></iframe>
         </div>
     </div>
 </li>


### PR DESCRIPTION
Embarquer des vidéos hébergées chez Framatube plutôt que chez YouTube paraît plus cohérent vis-à-vis du sujet traité sur ce site, et évite d'imposer des trackers YouTube en première page. La vidéo « Je n'ai rien à cacher » est également plus récente (et sans coupures de son). Ajout également d'un lien vers le transcript de cette vidéo, réalisé par l'April.
